### PR TITLE
Update links to lead to the correct github repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,5 +71,5 @@ deploy:
   on:
     tags: true
     python: "2.7"
-    repo: remileduc/invenio-archivematica
+    repo: inveniosoftware/invenio-archivematica
     condition: $DEPLOY = true

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -10,7 +10,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/remileduc/invenio-archivematica/issues.
+Report bugs at https://github.com/inveniosoftware/invenio-archivematica/issues.
 
 If you are reporting a bug, please include:
 
@@ -41,7 +41,7 @@ Submit Feedback
 ~~~~~~~~~~~~~~~
 
 The best way to send feedback is to file an issue at
-https://github.com/remileduc/invenio-archivematica/issues.
+https://github.com/inveniosoftware/invenio-archivematica/issues.
 
 If you are proposing a feature:
 
@@ -55,7 +55,7 @@ Get Started!
 
 Ready to contribute? Here's how to set up `invenio-archivematica` for local development.
 
-1. Fork the `remileduc/invenio-archivematica` repo on GitHub.
+1. Fork the `inveniosoftware/invenio-archivematica` repo on GitHub.
 2. Clone your fork locally:
 
    .. code-block:: console
@@ -114,5 +114,5 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring.
 3. The pull request should work for Python 2.7, 3.3, 3.4 and 3.5. Check
-   https://travis-ci.org/remileduc/invenio-archivematica/pull_requests
+   https://travis-ci.org/inveniosoftware/invenio-archivematica/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/README.rst
+++ b/README.rst
@@ -25,20 +25,20 @@
  Invenio-Archivematica
 =======================
 
-.. image:: https://img.shields.io/travis/remileduc/invenio-archivematica.svg
-        :target: https://travis-ci.org/remileduc/invenio-archivematica
+.. image:: https://img.shields.io/travis/inveniosoftware/invenio-archivematica.svg
+        :target: https://travis-ci.org/inveniosoftware/invenio-archivematica
 
-.. image:: https://img.shields.io/coveralls/remileduc/invenio-archivematica.svg
-        :target: https://coveralls.io/r/remileduc/invenio-archivematica
+.. image:: https://img.shields.io/coveralls/inveniosoftware/invenio-archivematica.svg
+        :target: https://coveralls.io/r/inveniosoftware/invenio-archivematica
 
-.. image:: https://img.shields.io/github/tag/remileduc/invenio-archivematica.svg
-        :target: https://github.com/remileduc/invenio-archivematica/releases
+.. image:: https://img.shields.io/github/tag/inveniosoftware/invenio-archivematica.svg
+        :target: https://github.com/inveniosoftware/invenio-archivematica/releases
 
 .. image:: https://img.shields.io/pypi/dm/invenio-archivematica.svg
         :target: https://pypi.python.org/pypi/invenio-archivematica
 
-.. image:: https://img.shields.io/github/license/remileduc/invenio-archivematica.svg
-        :target: https://github.com/remileduc/invenio-archivematica/blob/master/LICENSE
+.. image:: https://img.shields.io/github/license/inveniosoftware/invenio-archivematica.svg
+        :target: https://github.com/inveniosoftware/invenio-archivematica/blob/master/LICENSE
 
 Invenio 3 module to connect Invenio to Archivematica
 

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -32,5 +32,5 @@ Happy hacking and thanks for flying Invenio-Archivematica.
 |   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: https://twitter.com/inveniosoftware
-|   GitHub: https://github.com/remileduc/invenio-archivematica
+|   GitHub: https://github.com/inveniosoftware/invenio-archivematica
 |   URL: http://inveniosoftware.org

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -149,7 +149,7 @@ html_theme_options = {
     'github_banner': True,
     'show_powered_by': False,
     'extra_nav_links': {
-        'invenio-archivematica@GitHub': 'https://github.com/remileduc/invenio-archivematica',
+        'invenio-archivematica@GitHub': 'https://github.com/inveniosoftware/invenio-archivematica',
         'invenio-archivematica@PyPI': 'https://pypi.python.org/pypi/invenio-archivematica/',
     }
 }

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     license='GPLv2',
     author='CERN',
     author_email='info@inveniosoftware.org',
-    url='https://github.com/remileduc/invenio-archivematica',
+    url='https://github.com/inveniosoftware/invenio-archivematica',
     packages=packages,
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Some URLs were still going to "remileduc/invenio-archivematica".
This should be changed to "inveniosoftware/invenio-archivematica" instead.
This also fixes the link to coveralls.io so that the coverage is visible in the readme now.