### PR TITLE
Update test_factories.py

### DIFF
--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -82,7 +82,7 @@ def test_transfer_cp(app, db, location):
     # SIPFile
     f = FileInstance.create()
     fcontent = b'weighted companion cube\n'
-    f.set_contents(BytesIO(fcontent), default_location=location.name)
+    f.set_contents(BytesIO(fcontent), default_location=location.uri)
     sfile = SIPFile(sip=sip, file=f, filepath='portal.txt')
     db.session.add(sfile)
     db.session.commit()
@@ -121,7 +121,7 @@ def test_transfer_rsync(app, db, location):
     # SIPFile
     f = FileInstance.create()
     fcontent = b'weighted companion cube\n'
-    f.set_contents(BytesIO(fcontent), default_location=location.name)
+    f.set_contents(BytesIO(fcontent), default_location=location.uri)
     sfile = SIPFile(sip=sip, file=f, filepath='portal.txt')
     db.session.add(sfile)
     db.session.commit()

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -27,6 +27,7 @@
 import json
 from os import path
 
+from flask import current_app
 from invenio_files_rest.models import FileInstance
 from invenio_sipstore.models import SIP, SIPFile, SIPMetadata, SIPMetadataType
 from six import BytesIO
@@ -42,7 +43,9 @@ def test_create_accessioned_id(db):
     ark = Archive.create(sip)
     db.session.commit()
     accessioned_id = factories.create_accession_id(ark)
-    assert accessioned_id == 'CERN-' + str(sip.id)
+    assert accessioned_id \
+        == current_app.config['ARCHIVEMATICA_ORGANIZATION_NAME'] + '-' \
+        + str(sip.id)
 
 
 def test_is_archivable_default(db):


### PR DESCRIPTION
This pull request updates two things in `test_factories.py`:

- `test_create_accessioned_id()` now runs through even when the Archivematica Organization Name was changed in the config file.

- fixes #13 where an archive folder was left behind by tests. 